### PR TITLE
bugfix/make-whole-even-div-clickable

### DIFF
--- a/mycss/styles.css
+++ b/mycss/styles.css
@@ -43,7 +43,7 @@ body{
 .schedule{
     background-color: #212121;
     color: #fff;
-    padding: 12px;
+    padding: 8px 12px;
     margin-top: 10px;
     border-radius: 4px;
     text-align: center;
@@ -52,6 +52,11 @@ body{
     width: 88%;
     cursor: pointer;
     transition: all 0.3s ease;
+    max-height: 60px;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .schedule:hover{
@@ -63,6 +68,10 @@ body{
     text-decoration: none; 
     color: inherit; 
     cursor: pointer;
+    display: block;
+    width: 100%;
+    height: 100%;
+    text-align: center;
 }
 
 .event-link:hover {


### PR DESCRIPTION
Previously, only the (hidden) hyperlink of the event description was clickable, now the whole event-link/schedule div should be clickable whilst not preventing the ability to click on the day box too (in case the user wants to add an event through the calendar).